### PR TITLE
Populate name field on user-feedback card

### DIFF
--- a/lib/integrations/typeform.js
+++ b/lib/integrations/typeform.js
@@ -73,7 +73,7 @@ module.exports = class TypeformIntegration {
 			time: timestamp,
 			actor: adminActorId,
 			card: {
-				name: '',
+				name: `Feedback from ${username || 'unknown user'}`,
 				type: 'user-feedback@1.0.0',
 				slug,
 				active: true,


### PR DESCRIPTION
Change-type: major
Signed-off-by: Graham McCulloch <graham@balena.io>

---

Very small change - this will make the snippet title/link more user-friendly, displaying `Feedback from <user>` rather than `user-feedback-<uuid>`. I've made this a **major** change just because it will break some integration tests in Jellyfish - so I'll need to create a PR there to update the fixtures accordingly!