### PR TITLE
Require Node v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/product-os/jellyfish-sync.git"
   },
   "engines": {
-    "node": ">=12.15.0"
+    "node": ">=14.2.0"
   },
   "description": "Sync library for Jellyfish",
   "main": "lib/index.js",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Require Node v14 as that is what we use during CI and in production.
Setting the minimum at v14.2.0 as that is what balenaCI uses when running v14 tests.