### PR TITLE
Remove husky postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
   },
   "scripts": {
     "test": "npm run doc && catch-uncommitted --skip-node-versionbot-changes && make lint && make test",
-    "doc": "jsdoc2md --template doc/README.hbs lib/index.js > README.md",
-    "postinstall": "is-ci || husky install"
+    "doc": "jsdoc2md --template doc/README.hbs lib/index.js > README.md"
   },
   "author": "Balena.io. <hello@balena.io>",
   "license": "UNLICENSED",
@@ -69,7 +68,6 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "husky": "^5.0.4",
-    "is-ci": "^2.0.0",
     "jsdoc-to-markdown": "^6.0.1",
     "lint-staged": "^10.5.3",
     "nock": "^13.0.5"


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Removing postinstall for husky as it has causes errors on balenaCI. Will look at ways around this tomorrow.