### PR TITLE
Add fallback for company name in balena-api integration

### DIFF
--- a/lib/integrations/balena-api.js
+++ b/lib/integrations/balena-api.js
@@ -95,7 +95,7 @@ const mergeUserKeys = (preExistingCard, card, payload, cardType) => {
 	updateProperty(
 		card,
 		[ 'data', 'profile', 'company' ],
-		_.get(_.first(companyArray), [ 'company_name' ])
+		_.get(_.first(companyArray), [ 'company_name' ]) || payload.payload.company
 	)
 
 	updateProperty(


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Without this, the balena-api translate tests fail with:
```
  (1) new-user-invalid-ip

  Difference:

    {
      active: true,
      capabilities: [],
      created_at: '2020-12-16T05:54:17.407Z',
      data: {
        email: 'johndoe@souvlakitek.com',
        hash: 'PASSWORDLESS',
        mirrors: [
          'https://api.balena-cloud.com/v5/user(999)',
        ],
        profile: {
  -       company: 'Souvlaki Tek',
          name: Object { … },
          type: 'professional',
        },
        roles: [
          'user-external-support',
        ],
      },
      id: '33d65cd0-9486-433f-a919-2a82477d7a5b',
      linked_at: {
        'has attached element': '2020-12-16T05:54:17.437Z',
      },
      name: 'johndoe',
      requires: [],
      slug: 'user-johndoe',
      tags: [],
      type: 'user@1.0.0',
      updated_at: null,
      version: '1.0.0',
    }

  › webhookScenario (test/integration/sync/scenario.js:204:7)
  › test/integration/sync/scenario.js:433:6

  ─

  `--fail-fast` is on. At least 26 tests were skipped.

  1 test failed
```