### PR TITLE
Move sync specific interface code out of action-library module

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ const assert = require('@balena/jellyfish-assert')
 const instance = require('./instance')
 const oauth = require('./oauth')
 const errors = require('./errors')
+const syncContext = require('./sync-context')
 const metrics = require('@balena/jellyfish-metrics')
 
 /**
@@ -361,5 +362,10 @@ exports.Sync = class Sync {
 			provider: integration,
 			context
 		})
+	}
+
+	// eslint-disable-next-line class-methods-use-this
+	getActionContext (provider, workerContext, context, session) {
+		return syncContext.getActionContext(provider, workerContext, context, session)
 	}
 }

--- a/lib/sync-context.js
+++ b/lib/sync-context.js
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const _ = require('lodash')
+const jsonpatch = require('fast-json-patch')
+const logger = require('@balena/jellyfish-logger').getLogger(__filename)
+const assert = require('@balena/jellyfish-assert')
+
+/*
+ * Deal with some username differences that we can't
+ * fix in any other way.
+ */
+const ACTOR_TRANSLATORS = {
+	discourse: [
+		{
+			local: 'page-',
+			remote: '_page'
+		}
+	]
+}
+
+/**
+ * @name getActionContext
+ * @description This function generates a "context" object that provides a common interface for use by sync integrations.
+ *
+ * @param {String} provider - The name of the integration e.g. 'github', 'discourse'
+ * @param {Object} workerContext - Context object provided to action functions by
+ * the jellyfish worker
+ * @param {Object} context - Logging context object
+ * @param {String} session - session token used to interact with Jellyfish
+ *
+ * @returns {Object}
+ *
+ * @example
+ *
+ * const handler = async (session, context, card, request) => {
+ * 	const syncContext = context.sync.getActionContext(request.arguments.provider,
+ * 			context, request.context, context.privilegedSession)
+ * 	)
+ * 	.....
+ * }
+ */
+exports.getActionContext = (provider, workerContext, context, session) => {
+	const getDefaultActor = async () => {
+		const sessionCard = await workerContext.getCardById(
+			session, session)
+
+		if (!sessionCard) {
+			return null
+		}
+
+		return sessionCard.data.actor
+	}
+
+	const contextObject = {
+		log: {
+			warn: (message, data) => {
+				logger.warn(context, message, data)
+			},
+			error: (message, data) => {
+				logger.error(context, message, data)
+			},
+			debug: (message, data) => {
+				logger.debug(context, message, data)
+			},
+			info: (message, data) => {
+				logger.info(context, message, data)
+			}
+		},
+		getLocalUsername: (username) => {
+			const map = _.find(ACTOR_TRANSLATORS[provider] || [], {
+				remote: username
+			})
+
+			return map ? map.local : username
+		},
+		getRemoteUsername: (username) => {
+			const map = _.find(ACTOR_TRANSLATORS[provider] || [], {
+				local: username
+			})
+
+			return map ? map.remote : username
+		},
+		upsertElement: async (type, object, options) => {
+			const typeCard = await workerContext.getCardBySlug(
+				session, type)
+
+			assert.INTERNAL(context, typeCard,
+				workerContext.errors.WorkerNoElement, `No such type: ${type}`)
+
+			const actor = options.actor || await getDefaultActor()
+
+			const current = await workerContext.getCardBySlug(
+				session, `${object.slug}@${object.version}`)
+
+			if (!current) {
+				logger.info(context, 'Inserting card from sync context', object)
+				return workerContext.insertCard(session, typeCard, {
+					attachEvents: true,
+					timestamp: options.timestamp,
+					actor,
+					originator: options.originator
+				}, object).catch((error) => {
+					// Retry, and next time we will automatically go
+					// to through patch approach
+					if (error.name === 'JellyfishElementAlreadyExists') {
+						return contextObject.upsertElement(type, object, options)
+					}
+
+					throw error
+				})
+			}
+
+			// TODO: Expose a JSON patch interface on this function
+			// so we don't have to do this diff comparison thing.
+			const patch = jsonpatch.compare(
+				workerContext.defaults(current),
+				workerContext.defaults(Object.assign({}, object, {
+					id: current.id,
+					name: typeof object.name === 'string'
+						? object.name
+						: current.name || null,
+					created_at: current.created_at,
+					updated_at: current.updated_at,
+					linked_at: current.linked_at,
+					type: current.type
+				})))
+
+			logger.info(context, 'Patching card from sync context', {
+				slug: current.slug,
+				patch
+			})
+
+			return workerContext.patchCard(session, typeCard, {
+				attachEvents: true,
+				timestamp: options.timestamp,
+				actor,
+				originator: options.originator
+			}, current, patch)
+		},
+		getElementBySlug: async (slug) => {
+			return workerContext.getCardBySlug(session, slug)
+		},
+		getElementById: async (id) => {
+			return workerContext.getCardById(session, id)
+		},
+		getElementByMirrorId: async (type, mirrorId, options = {}) => {
+			assert.INTERNAL(context, mirrorId,
+				Error, 'You must supply a mirrorId as key')
+
+			const elements = await workerContext.query(session, {
+				type: 'object',
+				required: [ 'type', 'data' ],
+				additionalProperties: true,
+				properties: {
+					type: {
+						type: 'string',
+						const: type
+					},
+					data: {
+						type: 'object',
+						required: [ 'mirrors' ],
+						additionalProperties: true,
+						properties: {
+							mirrors: {
+								type: 'array',
+								contains: options.usePattern ? {
+									type: 'string',
+									pattern: mirrorId
+								} : {
+									type: 'string',
+									const: mirrorId
+								}
+							}
+						}
+					}
+				}
+			}, {
+				limit: 1
+			})
+
+			return elements[0]
+		}
+	}
+
+	return contextObject
+}

--- a/lib/sync-context.spec.js
+++ b/lib/sync-context.spec.js
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const _ = require('lodash')
+const ava = require('ava')
+const {
+	getActionContext
+} = require('./sync-context')
+const skhema = require('skhema')
+
+const makeWorkerContextStub = (cardFixtures) => {
+	return {
+		query: (_session, schema) => {
+			return _.filter(cardFixtures, (card) => {
+				return skhema.isValid(schema, card)
+			})
+		}
+	}
+}
+
+ava('context.getElementByMirrorId() should match mirrors exactly', async (test) => {
+	const mirrorId = 'test://1'
+	const card1 = {
+		type: 'card',
+		data: {
+			mirrors: [
+				mirrorId
+			]
+		}
+	}
+
+	const card2 = {
+		type: 'card',
+		data: {
+			mirrors: [
+				'test://2'
+			]
+		}
+	}
+
+	const workerContextStub = makeWorkerContextStub([
+		card1,
+		card2
+	])
+
+	const context = getActionContext({}, workerContextStub, {}, '')
+
+	const result = await context.getElementByMirrorId('card', mirrorId)
+
+	test.deepEqual(result, card1)
+})
+
+ava('context.getElementByMirrorId() should match by type', async (test) => {
+	const mirrorId = 'test://1'
+	const card1 = {
+		type: 'card',
+		data: {
+			mirrors: [
+				mirrorId
+			]
+		}
+	}
+
+	const card2 = {
+		type: 'foo',
+		data: {
+			mirrors: [
+				mirrorId
+			]
+		}
+	}
+
+	const workerContextStub = makeWorkerContextStub([
+		card1,
+		card2
+	])
+
+	const context = getActionContext({}, workerContextStub, {}, '')
+
+	const result = await context.getElementByMirrorId('card', mirrorId)
+
+	test.deepEqual(result, card1)
+})
+
+ava('context.getElementByMirrorId() should not return anything if there is no match', async (test) => {
+	const mirrorId = 'test://1'
+	const card1 = {
+		type: 'card',
+		data: {
+			mirrors: [
+				mirrorId
+			]
+		}
+	}
+
+	const card2 = {
+		type: 'card',
+		data: {
+			mirrors: [
+				'test://2'
+			]
+		}
+	}
+
+	const workerContextStub = makeWorkerContextStub([
+		card1,
+		card2
+	])
+
+	const context = getActionContext({}, workerContextStub, {}, '')
+
+	const result = await context.getElementByMirrorId('card', 'foobarbaz')
+
+	test.falsy(result)
+})
+
+ava('context.getElementByMirrorId() should optionally use a pattern match for the mirror Id', async (test) => {
+	const card1 = {
+		type: 'card',
+		data: {
+			mirrors: [
+				'test://foo/1'
+			]
+		}
+	}
+
+	const card2 = {
+		type: 'card',
+		data: {
+			mirrors: [
+				'test://bar/2'
+			]
+		}
+	}
+
+	const workerContextStub = makeWorkerContextStub([
+		card1,
+		card2
+	])
+
+	const context = getActionContext({}, workerContextStub, {}, '')
+
+	const result = await context.getElementByMirrorId('card', 'foo/1', {
+		usePattern: true
+	})
+
+	test.deepEqual(result, card1)
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -212,13 +212,13 @@
       }
     },
     "@balena/jellyfish-logger": {
-      "version": "0.0.217",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-0.0.217.tgz",
-      "integrity": "sha512-u2F/DD78B7FGEKVSAHaI82ZReZ9uSWUG4ox3iXXzBtGnG/JXivgxEPq1ucRkAJR/bux2ifpw0+WmKGp5zKXocw==",
+      "version": "0.0.216",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-0.0.216.tgz",
+      "integrity": "sha512-lD8BT86ewUAhTf/e6UfvTVMwJ/PaARok+0kfVSDYJZfvezUwn95Bfj+Jdo5ZYS4ni7rx824TtNM9SdR9nKP3hg==",
       "requires": {
         "@balena/jellyfish-assert": "^1.0.51",
         "@balena/jellyfish-environment": "^2.3.32",
-        "@sentry/node": "^6.0.2",
+        "@sentry/node": "^6.0.1",
         "errio": "^1.2.2",
         "le_node": "^1.8.0",
         "lodash": "^4.17.20",
@@ -236,6 +236,23 @@
         "@balena/node-metrics-gatherer": "^5.7.3",
         "express": "^4.17.1",
         "lodash": "^4.17.20"
+      },
+      "dependencies": {
+        "@balena/jellyfish-logger": {
+          "version": "0.0.217",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-logger/-/jellyfish-logger-0.0.217.tgz",
+          "integrity": "sha512-u2F/DD78B7FGEKVSAHaI82ZReZ9uSWUG4ox3iXXzBtGnG/JXivgxEPq1ucRkAJR/bux2ifpw0+WmKGp5zKXocw==",
+          "requires": {
+            "@balena/jellyfish-assert": "^1.0.51",
+            "@balena/jellyfish-environment": "^2.3.32",
+            "@sentry/node": "^6.0.2",
+            "errio": "^1.2.2",
+            "le_node": "^1.8.0",
+            "lodash": "^4.17.20",
+            "typed-errors": "^1.1.0",
+            "winston": "^3.3.3"
+          }
+        }
       }
     },
     "@balena/node-metrics-gatherer": {
@@ -476,6 +493,12 @@
         "@types/range-parser": "*"
       }
     },
+    "@types/json-schema": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-6.0.1.tgz",
+      "integrity": "sha512-vuL/tG01yKO//gmCmnV3OZhx2hs538t+7FpQq//sUV1sF6xiKi5V8F60dvAxe/HkC4+QaMCHqrm/akqlppTAkQ==",
+      "dev": true
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -592,6 +615,12 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
+    },
+    "ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true
     },
     "ansi-align": {
       "version": "3.0.0",
@@ -1181,6 +1210,12 @@
         }
       }
     },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1556,6 +1591,29 @@
       "integrity": "sha512-f0QqPLpRTgMQn/pQIynf+SdE73Lw5Q1jn4hjirHLgH/NJ71TiHjXusV16BmOyuK5rRQ1W2f++II+TFZbQOh4hA==",
       "dev": true
     },
+    "compute-gcd": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.1.tgz",
+      "integrity": "sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==",
+      "dev": true,
+      "requires": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
+    },
+    "compute-lcm": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.2.tgz",
+      "integrity": "sha512-OFNPdQAXnQhDSKioX8/XYT6sdUlXwpeMjfd6ApxMJfyZ4GxmLR1xvMERctlYhlHwIiz6CSpBc2+qYKjHGZw4TQ==",
+      "dev": true,
+      "requires": {
+        "compute-gcd": "^1.2.1",
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1766,6 +1824,12 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
+    },
+    "deep-copy": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/deep-copy/-/deep-copy-1.4.2.tgz",
+      "integrity": "sha512-VxZwQ/1+WGQPl5nE67uLhh7OqdrmqI1OazrraO9Bbw/M8Bt6Mol/RxzDA6N6ZgRXpsG/W9PgUj8E1LHHBEq2GQ==",
       "dev": true
     },
     "deep-extend": {
@@ -2035,6 +2099,12 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
       "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true
+    },
+    "drange": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
+      "integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==",
       "dev": true
     },
     "duplexer3": {
@@ -2749,6 +2819,11 @@
         "picomatch": "^2.2.1"
       }
     },
+    "fast-json-patch": {
+      "version": "3.0.0-1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.0.0-1.tgz",
+      "integrity": "sha512-6pdFb07cknxvPzCeLsFHStEy+MysPJPgZQ9LbQ/2O67unQF93SNqfdSqnPPl71YMHX+AD8gbl7iuoGFzHEdDuw=="
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2758,6 +2833,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fast-memoize": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
+      "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==",
       "dev": true
     },
     "fast-safe-stringify": {
@@ -2897,6 +2978,12 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "format-util": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.5.tgz",
+      "integrity": "sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg==",
+      "dev": true
     },
     "forwarded": {
       "version": "0.1.2",
@@ -3851,6 +3938,48 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
+    "json-schema-compare": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
+      "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4"
+      }
+    },
+    "json-schema-faker": {
+      "version": "0.5.0-rcv.32",
+      "resolved": "https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.5.0-rcv.32.tgz",
+      "integrity": "sha512-buGuuOhzxrf9FWGFybiGNiflGODIC5doU0r23+3MAOyjMR9/KsKolHANSbQnM4N+mmw/dbv9byT3oKZ1wp8v2A==",
+      "dev": true,
+      "requires": {
+        "json-schema-ref-parser": "^6.1.0",
+        "jsonpath-plus": "^3.0.0",
+        "randexp": "^0.5.3"
+      }
+    },
+    "json-schema-merge-allof": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.6.0.tgz",
+      "integrity": "sha512-LEw4VMQVRceOPLuGRWcxW5orTTiR9ZAtqTAe4rQUjNADTeR81bezBVFa0MqIwp0YmHIM1KkhSjZM7o+IQhaPbQ==",
+      "dev": true,
+      "requires": {
+        "compute-lcm": "^1.1.0",
+        "json-schema-compare": "^0.2.2",
+        "lodash": "^4.17.4"
+      }
+    },
+    "json-schema-ref-parser": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz",
+      "integrity": "sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^3.12.1",
+        "ono": "^4.0.11"
+      }
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -3874,6 +4003,12 @@
       "requires": {
         "minimist": "^1.2.0"
       }
+    },
+    "jsonpath-plus": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-3.0.0.tgz",
+      "integrity": "sha512-WQwgWEBgn+SJU1tlDa/GiY5/ngRpa9yrSj8n4BYPHcwoxTDaMEaYCHMOn42hIHHDd3CrUoRr3+HpsK0hCKoxzA==",
+      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
@@ -4590,6 +4725,15 @@
         "mimic-fn": "^2.1.0"
       }
     },
+    "ono": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
+      "integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
+      "dev": true,
+      "requires": {
+        "format-util": "^1.0.3"
+      }
+    },
     "optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -5002,6 +5146,16 @@
       "requires": {
         "invariant": "2.2.2",
         "lodash": "^4.17.15"
+      }
+    },
+    "randexp": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.5.3.tgz",
+      "integrity": "sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==",
+      "dev": true,
+      "requires": {
+        "drange": "^1.0.2",
+        "ret": "^0.2.0"
       }
     },
     "randomstring": {
@@ -5431,6 +5585,12 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "ret": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+      "dev": true
+    },
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -5644,6 +5804,41 @@
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
           "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        }
+      }
+    },
+    "skhema": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/skhema/-/skhema-5.3.3.tgz",
+      "integrity": "sha512-jCfJnPSnZtT3zybzvX6ZuNiz0aHyTT84hcUG3tZi3nDXg0C1AI8JbZP+Kou8Cvsh782WWPnO6k4+xxDx7z0RQA==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^6.0.1",
+        "ajv": "^6.5.1",
+        "ajv-keywords": "^3.2.0",
+        "deep-copy": "^1.4.2",
+        "fast-memoize": "^2.5.1",
+        "json-schema-faker": "^0.5.0-rc16",
+        "json-schema-merge-allof": "^0.6.0",
+        "lodash": "^4.17.19",
+        "lru-cache": "^5.1.1",
+        "typed-error": "^3.2.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true
         }
       }
     },
@@ -6298,6 +6493,43 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validate.io-array": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
+      "integrity": "sha1-W1osr9j4uFq7L4hroVPy2Tond00=",
+      "dev": true
+    },
+    "validate.io-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
+      "integrity": "sha1-NDoZgC7TsZaCaceA5VjpNBHAutc=",
+      "dev": true
+    },
+    "validate.io-integer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
+      "integrity": "sha1-FoSWSAuVviJH7EQ/IjPeT4mHgGg=",
+      "dev": true,
+      "requires": {
+        "validate.io-number": "^1.0.3"
+      }
+    },
+    "validate.io-integer-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
+      "integrity": "sha1-LKveAzKTpry+Bj/q/pHq9GsToIk=",
+      "dev": true,
+      "requires": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-integer": "^1.0.4"
+      }
+    },
+    "validate.io-number": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
+      "integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg=",
+      "dev": true
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,10 @@
   "license": "UNLICENSED",
   "dependencies": {
     "@balena/jellyfish-assert": "^1.0.51",
+    "@balena/jellyfish-logger": "0.0.216",
     "@balena/jellyfish-metrics": "^0.1.36",
     "bluebird": "^3.7.2",
+    "fast-json-patch": "^3.0.0-1",
     "json-e": "^4.3.0",
     "lodash": "^4.17.20",
     "marked": "^1.2.7",
@@ -56,6 +58,7 @@
     "husky": "^5.0.6",
     "jsdoc-to-markdown": "^6.0.1",
     "lint-staged": "^10.5.3",
+    "skhema": "^5.3.3",
     "nock": "^13.0.6"
   },
   "lint-staged": {


### PR DESCRIPTION
This commit moves the `sync-context` code from the action library module
into the sync module here. Keeping all sync related code in one place
seems very sensible, especially as this code contains some complex
business logic that should be unit tested alongside the rest of the sync
framework. Once this is merged, the action library module can be updated
to use this code and we can delete the original files.

The source code copied across comes from v6.0.85 of the `action-library`
module: https://github.com/product-os/jellyfish-action-library/blob/v6.0.85/lib/handlers/sync-context.js

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>