### PR TITLE
When upserting an element, only patch cards that have a matching ID

### DIFF
--- a/lib/sync-context.js
+++ b/lib/sync-context.js
@@ -114,6 +114,12 @@ exports.getActionContext = (provider, workerContext, context, session) => {
 				})
 			}
 
+			// If the patch is being applied over a different card, something has gone
+			// wrong
+			if (current.id !== object.id) {
+				throw new Error(`Cannot patch over existing card: ${object.slug}`)
+			}
+
 			// TODO: Expose a JSON patch interface on this function
 			// so we don't have to do this diff comparison thing.
 			const patch = jsonpatch.compare(

--- a/lib/sync-context.spec.js
+++ b/lib/sync-context.spec.js
@@ -10,6 +10,7 @@ const {
 	getActionContext
 } = require('./sync-context')
 const skhema = require('skhema')
+const sinon = require('sinon')
 
 const makeWorkerContextStub = (cardFixtures) => {
 	return {
@@ -17,7 +18,17 @@ const makeWorkerContextStub = (cardFixtures) => {
 			return _.filter(cardFixtures, (card) => {
 				return skhema.isValid(schema, card)
 			})
-		}
+		},
+		getCardBySlug: (_session, slugWithVersion) => {
+			const slug = slugWithVersion.split('@')[0]
+			return _.find(cardFixtures, {
+				slug
+			})
+		},
+		errors: {
+			WorkerNoElement: {}
+		},
+		defaults: _.identity
 	}
 }
 
@@ -148,4 +159,168 @@ ava('context.getElementByMirrorId() should optionally use a pattern match for th
 	})
 
 	test.deepEqual(result, card1)
+})
+
+ava('context.upsertElement() should throw if overwriting an existing card with a different id', async (test) => {
+	const typeCard = {
+		slug: 'card',
+		type: 'type',
+		data: {
+			schema: {
+				type: 'object'
+			}
+		}
+	}
+
+	const existingCard = {
+		slug: 'card-foo-bar',
+		type: 'card',
+		id: '12345',
+		data: {
+			lorem: 'ipsum'
+		}
+	}
+
+	const workerContextStub = makeWorkerContextStub([
+		typeCard,
+		existingCard
+	])
+
+	const upsertElementSpy = sinon.spy()
+
+	workerContextStub.upsertElement = upsertElementSpy
+
+	const context = getActionContext({}, workerContextStub, {}, '')
+
+	const inputObject = {
+		slug: 'card-foo-bar',
+		type: 'card',
+		data: {
+			lorem: 'dis amet'
+		}
+	}
+
+	const error = await test.throwsAsync(
+		context.upsertElement(
+			'card',
+			inputObject,
+			{
+				actor: 'product-os'
+			}
+		)
+	)
+
+	test.is(error.message, `Cannot patch over existing card: ${existingCard.slug}`)
+
+	// Test that upsertElement was not called
+	test.is(upsertElementSpy.callCount, 0)
+})
+
+ava('context.upsertElement() should create a new card if there is no existing card with the same slug', async (test) => {
+	const typeCard = {
+		slug: 'card',
+		type: 'type',
+		data: {
+			schema: {
+				type: 'object'
+			}
+		}
+	}
+
+	const workerContextStub = makeWorkerContextStub([
+		typeCard
+	])
+
+	const insertSpy = sinon.spy()
+
+	workerContextStub.insertCard = async (...args) => {
+		insertSpy(...args)
+	}
+
+	const context = getActionContext({}, workerContextStub, {
+		id: 1
+	}, '')
+
+	const inputObject = {
+		slug: 'card-foo-bar',
+		type: 'card',
+		data: {
+			lorem: 'dis amet'
+		}
+	}
+
+	await test.notThrowsAsync(
+		context.upsertElement(
+			'card',
+			inputObject,
+			{
+				actor: 'product-os'
+			}
+		)
+	)
+
+	test.is(insertSpy.firstCall.args[3], inputObject)
+})
+
+ava('context.upsertElement() should update an existing card with the same slug and id', async (test) => {
+	const typeCard = {
+		slug: 'card',
+		type: 'type',
+		data: {
+			schema: {
+				type: 'object'
+			}
+		}
+	}
+
+	const existingCard = {
+		slug: 'card-foo-bar',
+		type: 'card',
+		name: null,
+		id: '12345',
+		data: {
+			lorem: 'ipsum'
+		}
+	}
+
+	const workerContextStub = makeWorkerContextStub([
+		typeCard,
+		existingCard
+	])
+
+	const patchSpy = sinon.spy()
+
+	workerContextStub.patchCard = async (...args) => {
+		patchSpy(...args)
+	}
+
+	const context = getActionContext({}, workerContextStub, {
+		id: 1
+	}, '')
+
+	const inputObject = {
+		slug: existingCard.slug,
+		id: existingCard.id,
+		name: null,
+		type: 'card',
+		data: {
+			lorem: 'dis amet'
+		}
+	}
+
+	await test.notThrowsAsync(
+		context.upsertElement(
+			'card',
+			inputObject,
+			{
+				actor: 'product-os'
+			}
+		)
+	)
+
+	test.deepEqual(patchSpy.firstCall.lastArg, [ {
+		op: 'replace',
+		path: '/data/lorem',
+		value: inputObject.data.lorem
+	} ])
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -435,6 +435,37 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true
     },
+    "@sinonjs/commons": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
+      "integrity": "sha512-sruwd86RJHdsVf/AtBoijDmUqJp3B6hF/DGC23C+JaegnDHaZyewCjoVGTdg3J0uz3Zs7NnIT05OBOmML72lQw==",
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.1.tgz",
+      "integrity": "sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==",
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
+    },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -2040,6 +2071,11 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+    },
     "dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -3182,8 +3218,7 @@
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -4021,6 +4056,11 @@
         "verror": "1.10.0"
       }
     },
+    "just-extend": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
+      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA=="
+    },
     "keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -4220,6 +4260,11 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.omit": {
       "version": "4.5.0",
@@ -4548,6 +4593,33 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+      "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "nock": {
       "version": "13.0.6",
@@ -5807,6 +5879,19 @@
         }
       }
     },
+    "sinon": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
+      "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
+      "requires": {
+        "@sinonjs/commons": "^1.8.1",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/samsam": "^5.3.1",
+        "diff": "^4.0.2",
+        "nise": "^4.0.4",
+        "supports-color": "^7.1.0"
+      }
+    },
     "skhema": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/skhema/-/skhema-5.3.3.tgz",
@@ -6121,7 +6206,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
       "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
       }
@@ -6353,6 +6437,11 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-fest": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "marked": "^1.2.8",
     "randomstring": "^1.1.5",
     "request": "^2.88.2",
+    "sinon": "^9.2.4",
     "typed-errors": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
To prevent issues in syncing, integrations will need to start
namespacing derived slugs, e.g. the balena-api integration would use
a `-balena-api--` prefix when generating new slugs.

Change-type: major
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>