### PR TITLE
Add exception logger to sync context

### DIFF
--- a/lib/sync-context.js
+++ b/lib/sync-context.js
@@ -68,6 +68,11 @@ exports.getActionContext = (provider, workerContext, context, session) => {
 			},
 			info: (message, data) => {
 				logger.info(context, message, data)
+			},
+
+			// "exception" will log to sentry if it's enabled
+			exception: (message, error) => {
+				logger.exception(context, message, error)
 			}
 		},
 		getLocalUsername: (username) => {


### PR DESCRIPTION
This change will allow integrations to send errors to sentry if it's
enabled.

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>