### PR TITLE
When upserting an element, prefer to patch by ID

### DIFF
--- a/lib/sync-context.js
+++ b/lib/sync-context.js
@@ -89,6 +89,12 @@ exports.getActionContext = (provider, workerContext, context, session) => {
 
 			return map ? map.remote : username
 		},
+
+		// The upsertElement function has the property of being eventually
+		// consistent, sanely handling two seperate sync events on a new
+		// object with the same slug. If an ID is provided we don't need to do any
+		// checking though, as the object already exists and it can be patched
+		// immediately.
 		upsertElement: async (type, object, options) => {
 			const typeCard = await workerContext.getCardBySlug(
 				session, type)
@@ -98,8 +104,12 @@ exports.getActionContext = (provider, workerContext, context, session) => {
 
 			const actor = options.actor || await getDefaultActor()
 
-			const current = await workerContext.getCardBySlug(
-				session, `${object.slug}@${object.version}`)
+			// If an ID was passed in, use that ID to load the current card, this
+			// prevents the situation where an integration may unintentionally
+			// generate a new slug for an existing card.
+			const current = object.id
+				? await workerContext.getCardById(session, object.id)
+				: await workerContext.getCardBySlug(session, `${object.slug}@${object.version}`)
 
 			if (!current) {
 				logger.info(context, 'Inserting card from sync context', object)
@@ -125,6 +135,7 @@ exports.getActionContext = (provider, workerContext, context, session) => {
 				workerContext.defaults(current),
 				workerContext.defaults(Object.assign({}, object, {
 					id: current.id,
+					slug: current.slug,
 					name: typeof object.name === 'string'
 						? object.name
 						: current.name || null,

--- a/lib/sync-context.spec.js
+++ b/lib/sync-context.spec.js
@@ -10,13 +10,60 @@ const {
 	getActionContext
 } = require('./sync-context')
 const skhema = require('skhema')
+const sinon = require('sinon')
+const jsonpatch = require('fast-json-patch')
+const uuid = require('uuid')
 
 const makeWorkerContextStub = (cardFixtures) => {
+	const defaults = (contract) => {
+		if (!contract.id) {
+			contract.id = uuid.v4()
+		}
+		if (!contract.slug) {
+			contract.slug = `${contract.type}-${uuid.v4()}`
+		}
+
+		return contract
+	}
+
+	const store = _.cloneDeep(cardFixtures).map(defaults)
+
 	return {
-		query: (_session, schema) => {
-			return _.filter(cardFixtures, (card) => {
+		query: async (_session, schema) => {
+			return _.filter(store, (card) => {
 				return skhema.isValid(schema, card)
 			})
+		},
+		getCardBySlug: async (_session, slugWithVersion) => {
+			const slug = slugWithVersion.split('@')[0]
+			return _.find(store, {
+				slug
+			}) || null
+		},
+		getCardById: async (_session, id) => {
+			return _.find(store, {
+				id
+			}) || null
+		},
+		insertCard: async (_session, _typeCard, _options, object) => {
+			if (_.find(store, {
+				slug: object.slug
+			})) {
+				throw new Error(`${object.slug} already exists`)
+			}
+			store.push(defaults(object))
+			return object
+		},
+		patchCard: async (_session, _typeCard, _options, current, patch) => {
+			const existing = _.find(store, {
+				id: current.id
+			})
+			jsonpatch.applyPatch(existing, patch)
+			return existing
+		},
+		defaults,
+		errors: {
+			WorkerNoElement: {}
 		}
 	}
 }
@@ -24,6 +71,8 @@ const makeWorkerContextStub = (cardFixtures) => {
 ava('context.getElementByMirrorId() should match mirrors exactly', async (test) => {
 	const mirrorId = 'test://1'
 	const card1 = {
+		id: uuid.v4(),
+		slug: `card-${uuid.v4()}`,
 		type: 'card',
 		data: {
 			mirrors: [
@@ -33,6 +82,8 @@ ava('context.getElementByMirrorId() should match mirrors exactly', async (test) 
 	}
 
 	const card2 = {
+		id: uuid.v4(),
+		slug: `card-${uuid.v4()}`,
 		type: 'card',
 		data: {
 			mirrors: [
@@ -56,6 +107,8 @@ ava('context.getElementByMirrorId() should match mirrors exactly', async (test) 
 ava('context.getElementByMirrorId() should match by type', async (test) => {
 	const mirrorId = 'test://1'
 	const card1 = {
+		id: uuid.v4(),
+		slug: `card-${uuid.v4()}`,
 		type: 'card',
 		data: {
 			mirrors: [
@@ -65,6 +118,8 @@ ava('context.getElementByMirrorId() should match by type', async (test) => {
 	}
 
 	const card2 = {
+		id: uuid.v4(),
+		slug: `card-${uuid.v4()}`,
 		type: 'foo',
 		data: {
 			mirrors: [
@@ -119,6 +174,8 @@ ava('context.getElementByMirrorId() should not return anything if there is no ma
 
 ava('context.getElementByMirrorId() should optionally use a pattern match for the mirror Id', async (test) => {
 	const card1 = {
+		id: uuid.v4(),
+		slug: `card-${uuid.v4()}`,
 		type: 'card',
 		data: {
 			mirrors: [
@@ -128,6 +185,8 @@ ava('context.getElementByMirrorId() should optionally use a pattern match for th
 	}
 
 	const card2 = {
+		id: uuid.v4(),
+		slug: `card-${uuid.v4()}`,
 		type: 'card',
 		data: {
 			mirrors: [
@@ -148,4 +207,196 @@ ava('context.getElementByMirrorId() should optionally use a pattern match for th
 	})
 
 	test.deepEqual(result, card1)
+})
+
+ava('context.upsertElement() should create a new element', async (test) => {
+	const typeCard = {
+		type: 'type',
+		slug: 'card',
+		data: {
+			schema: {
+				type: 'object'
+			}
+		}
+	}
+
+	const workerContextStub = makeWorkerContextStub([
+		typeCard
+	])
+
+	const insertSpy = sinon.spy(workerContextStub, 'insertCard')
+	const patchSpy = sinon.spy(workerContextStub, 'patchCard')
+
+	const context = getActionContext({}, workerContextStub, {
+		id: 1
+	}, '')
+
+	const newCard = {
+		type: 'card',
+		slug: 'card-foobarbaz',
+		data: {
+			test: 1
+		}
+	}
+
+	const result = await context.upsertElement('card', newCard, {
+		actor: 'ahab'
+	})
+
+	test.true(insertSpy.calledOnce)
+	test.true(patchSpy.notCalled)
+
+	test.is(result.slug, newCard.slug)
+})
+
+ava('context.upsertElement() should patch an element if the slug exists but no id is provided', async (test) => {
+	const typeCard = {
+		type: 'type',
+		slug: 'card',
+		data: {
+			schema: {
+				type: 'object'
+			}
+		}
+	}
+
+	const card1 = {
+		type: 'card',
+		slug: 'card-foobarbaz',
+		data: {
+			test: 1
+		}
+	}
+
+	const newCard = {
+		...card1,
+		data: {
+			test: 2
+		}
+	}
+
+	const workerContextStub = makeWorkerContextStub([
+		typeCard,
+		card1
+	])
+
+	const insertSpy = sinon.spy(workerContextStub, 'insertCard')
+	const patchSpy = sinon.spy(workerContextStub, 'patchCard')
+
+	const context = getActionContext({}, workerContextStub, {
+		id: 1
+	}, '')
+
+	const result = await context.upsertElement('card', newCard, {
+		actor: 'ahab'
+	})
+
+	test.true(insertSpy.notCalled)
+	test.true(patchSpy.calledOnce)
+
+	test.is(result.slug, card1.slug)
+	test.is(result.data.test, newCard.data.test)
+})
+
+ava('context.upsertElement() should patch an element by id even if the slugs differ', async (test) => {
+	const typeCard = {
+		type: 'type',
+		slug: 'card',
+		data: {
+			schema: {
+				type: 'object'
+			}
+		}
+	}
+
+	const card1 = {
+		id: 'f41b64b3-153c-438d-b8f2-0c592f742b4c',
+		type: 'card',
+		slug: 'card-foobarbaz',
+		data: {
+			test: 1
+		}
+	}
+
+	const workerContextStub = makeWorkerContextStub([
+		typeCard,
+		card1
+	])
+
+	const insertSpy = sinon.spy(workerContextStub, 'insertCard')
+	const patchSpy = sinon.spy(workerContextStub, 'patchCard')
+
+	const context = getActionContext({}, workerContextStub, {
+		id: 1
+	}, '')
+
+	const newCard = {
+		...card1,
+		slug: `${card1.slug}-fuzzbuzzfizz`,
+		data: {
+			test: 2
+		}
+	}
+
+	const result = await context.upsertElement('card', newCard, {
+		actor: 'ahab'
+	})
+
+	test.true(insertSpy.notCalled)
+	test.true(patchSpy.calledOnce)
+
+	test.is(result.slug, card1.slug)
+	test.is(result.id, card1.id)
+	test.is(result.data.test, newCard.data.test)
+})
+
+ava('context.upsertElement() should patch an element by id when the slugs are the same', async (test) => {
+	const typeCard = {
+		type: 'type',
+		slug: 'card',
+		data: {
+			schema: {
+				type: 'object'
+			}
+		}
+	}
+
+	const card1 = {
+		id: 'f41b64b3-153c-438d-b8f2-0c592f742b4c',
+		type: 'card',
+		slug: 'card-foobarbaz',
+		data: {
+			test: 1
+		}
+	}
+
+	const workerContextStub = makeWorkerContextStub([
+		typeCard,
+		card1
+	])
+
+	const insertSpy = sinon.spy(workerContextStub, 'insertCard')
+	const patchSpy = sinon.spy(workerContextStub, 'patchCard')
+
+	const context = getActionContext({}, workerContextStub, {
+		id: 1
+	}, '')
+
+	const newCard = {
+		...card1,
+		data: {
+			test: 2
+		}
+	}
+
+	const result = await context.upsertElement('card', newCard, {
+		actor: 'ahab'
+	})
+
+	test.true(insertSpy.notCalled)
+	test.true(patchSpy.calledOnce)
+
+	test.is(result.slug, card1.slug)
+	test.is(result.id, card1.id)
+	test.is(result.data.test, newCard.data.test)
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -419,6 +419,41 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true
     },
+    "@sinonjs/commons": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
+      "integrity": "sha512-sruwd86RJHdsVf/AtBoijDmUqJp3B6hF/DGC23C+JaegnDHaZyewCjoVGTdg3J0uz3Zs7NnIT05OBOmML72lQw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.1.tgz",
+      "integrity": "sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -1999,6 +2034,12 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
+    },
     "dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -2737,7 +2778,8 @@
     "fast-json-patch": {
       "version": "3.0.0-1",
       "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.0.0-1.tgz",
-      "integrity": "sha512-6pdFb07cknxvPzCeLsFHStEy+MysPJPgZQ9LbQ/2O67unQF93SNqfdSqnPPl71YMHX+AD8gbl7iuoGFzHEdDuw=="
+      "integrity": "sha512-6pdFb07cknxvPzCeLsFHStEy+MysPJPgZQ9LbQ/2O67unQF93SNqfdSqnPPl71YMHX+AD8gbl7iuoGFzHEdDuw==",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -3780,6 +3822,12 @@
         "verror": "1.10.0"
       }
     },
+    "just-extend": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
+      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
+      "dev": true
+    },
     "keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -3908,6 +3956,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.omit": {
@@ -4243,6 +4297,36 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
       "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
+    },
+    "nise": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+      "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "nock": {
       "version": "13.0.7",
@@ -5463,6 +5547,20 @@
         }
       }
     },
+    "sinon": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
+      "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.1",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/samsam": "^5.3.1",
+        "diff": "^4.0.2",
+        "nise": "^4.0.4",
+        "supports-color": "^7.1.0"
+      }
+    },
     "skhema": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/skhema/-/skhema-5.3.3.tgz",
@@ -6004,6 +6102,12 @@
         "prelude-ls": "^1.2.1"
       }
     },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
     "type-fest": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
@@ -6127,6 +6231,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@balena/jellyfish-logger": "1.0.11",
     "@balena/jellyfish-metrics": "^0.1.69",
     "bluebird": "^3.7.2",
-    "fast-json-patch": "^3.0.0-1",
     "json-e": "^4.3.0",
     "lodash": "^4.17.20",
     "randomstring": "^1.1.5",
@@ -54,11 +53,14 @@
     "eslint-plugin-lodash": "^7.1.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
+    "fast-json-patch": "^3.0.0-1",
     "husky": "^5.0.9",
     "jsdoc-to-markdown": "^6.0.1",
     "lint-staged": "^10.5.4",
+    "nock": "^13.0.7",
+    "sinon": "^9.2.4",
     "skhema": "^5.3.3",
-    "nock": "^13.0.7"
+    "uuid": "^8.3.2"
   },
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
This change means that if an ID is provided to upsertElement, it will
prefer to patch by id than slug. This means that you can change how
deterministic slugs are generated inside integrations without disrupting
contract data that is already synced to Jellyfish.
This should have no effect on the current system and is 100% backwards
compatible with existing integrations.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>