### PR TITLE
Add support for JSONpatch when upserting elements

### DIFF
--- a/lib/sync-context.js
+++ b/lib/sync-context.js
@@ -95,6 +95,9 @@ exports.getActionContext = (provider, workerContext, context, session) => {
 		// object with the same slug. If an ID is provided we don't need to do any
 		// checking though, as the object already exists and it can be patched
 		// immediately.
+		// Object can either be a partial contract object or an object with keys
+		// "id" and "patch", where id is the id of the target contract and patch is
+		// a jsonpatch
 		upsertElement: async (type, object, options) => {
 			const typeCard = await workerContext.getCardBySlug(
 				session, type)
@@ -129,21 +132,26 @@ exports.getActionContext = (provider, workerContext, context, session) => {
 				})
 			}
 
-			// TODO: Expose a JSON patch interface on this function
+			// TODO: Migrate all integrations to use the JSON patch interface on this function
 			// so we don't have to do this diff comparison thing.
-			const patch = jsonpatch.compare(
-				workerContext.defaults(current),
-				workerContext.defaults(Object.assign({}, object, {
-					id: current.id,
-					slug: current.slug,
-					name: typeof object.name === 'string'
-						? object.name
-						: current.name || null,
-					created_at: current.created_at,
-					updated_at: current.updated_at,
-					linked_at: current.linked_at,
-					type: current.type
-				})))
+			let patch = []
+			if (object.patch && object.patch.length) {
+				patch = object.patch
+			} else {
+				patch = jsonpatch.compare(
+					workerContext.defaults(current),
+					workerContext.defaults(Object.assign({}, object, {
+						id: current.id,
+						slug: current.slug,
+						name: typeof object.name === 'string'
+							? object.name
+							: current.name || null,
+						created_at: current.created_at,
+						updated_at: current.updated_at,
+						linked_at: current.linked_at,
+						type: current.type
+					})))
+			}
 
 			logger.info(context, 'Patching card from sync context', {
 				slug: current.slug,

--- a/lib/sync-context.spec.js
+++ b/lib/sync-context.spec.js
@@ -400,3 +400,56 @@ ava('context.upsertElement() should patch an element by id when the slugs are th
 	test.is(result.id, card1.id)
 	test.is(result.data.test, newCard.data.test)
 })
+
+ava('context.upsertElement() should patch an element using a patch object', async (test) => {
+	const typeCard = {
+		type: 'type',
+		slug: 'card',
+		data: {
+			schema: {
+				type: 'object'
+			}
+		}
+	}
+
+	const card1 = {
+		id: 'f41b64b3-153c-438d-b8f2-0c592f742b4c',
+		type: 'card',
+		slug: 'card-foobarbaz',
+		data: {
+			test: 1
+		}
+	}
+
+	const workerContextStub = makeWorkerContextStub([
+		typeCard,
+		card1
+	])
+
+	const insertSpy = sinon.spy(workerContextStub, 'insertCard')
+	const patchSpy = sinon.spy(workerContextStub, 'patchCard')
+
+	const context = getActionContext({}, workerContextStub, {
+		id: 1
+	}, '')
+
+	const update = {
+		id: card1.id,
+		patch: [ {
+			op: 'replace',
+			path: '/data/test',
+			value: 2
+		} ]
+	}
+
+	const result = await context.upsertElement('card', update, {
+		actor: 'ahab'
+	})
+
+	test.true(insertSpy.notCalled)
+	test.true(patchSpy.calledOnce)
+
+	test.is(result.slug, card1.slug)
+	test.is(result.id, card1.id)
+	test.is(result.data.test, update.patch[0].value)
+})


### PR DESCRIPTION
This change adds support for JSONpatch object in the `SyncContext.upsertElement`
method. This means we can reduce ambiguity when updating contracts in
integrations. This will mainly affect `Integration.translate` methods,
which currently return an array of partial contracts to upsert. The
current approach will continue to work whilst we migrate integrations to
use JSONpatch instead.

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>