### PR TITLE
Update importCards sequence parameter type

### DIFF
--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -140,7 +140,7 @@ const evaluateObject = (object: any, environment: any) => {
  */
 export const importCards = async (
 	context: PipelineOpts['context'],
-	sequence: SequenceItem[],
+	sequence: Array<SequenceItem | SequenceItem[]>,
 	options: any = {},
 ) => {
 	// TODO: AFAICT the references option is never provided and can probably be removed


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

The `pipeline` tests in `plugin-default` expect `importCards()` to be able to take an array of `SequenceItem`s, and array of an array of `SequenceItem`s, and a combination of the two:
- https://github.com/product-os/jellyfish-plugin-default/blob/master/test/integration/sync/pipeline.spec.js#L137
- https://github.com/product-os/jellyfish-plugin-default/blob/master/test/integration/sync/pipeline.spec.js#L193
- https://github.com/product-os/jellyfish-plugin-default/blob/master/test/integration/sync/pipeline.spec.js#L382