### PR TITLE
allow sequences returned from translate to specify of originator should be passed along

### DIFF
--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -223,7 +223,9 @@ export const importCards = async (
 				const result = await context.upsertElement(type, finalObject, {
 					timestamp: segment.time,
 					actor: segment.actor,
-					originator: _.get(options, ['origin', 'id']),
+					originator: segment.skipOriginator
+						? null
+						: _.get(options, ['origin', 'id']),
 				});
 
 				if (result) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -80,6 +80,13 @@ export interface PipelineOpts {
 export interface SequenceItem {
 	time: Date;
 	actor: string;
+	/**
+	 * If this is set, we don't set an originator when inserting this card.
+	 * This treats this as a new request.
+	 * This is being used to allow inserting contracts as part of a translate which
+	 * should be mirrored again.
+	 */
+	skipOriginator?: boolean;
 	card:
 		| (Partial<JellyfishTypes.core.Contract> &
 				Pick<JellyfishTypes.core.Contract, 'slug' | 'type'>)


### PR DESCRIPTION

Change-type: minor
Signed-off-by: Martin Rauscher <martin@balena.io>
Co-authored-by: Lucian Buzzo <lucian@balena.io>