### PR TITLE
Skip pointless updates to /data/origin

### DIFF
--- a/lib/sync-context.ts
+++ b/lib/sync-context.ts
@@ -208,6 +208,12 @@ export const getActionContext = (
 				patch,
 			});
 
+			// If the only thing being updated is the origin, skip the update as
+			// it is a meaningless change.
+			if (patch.length === 1 && patch[0].path === '/data/origin') {
+				return current;
+			}
+
 			return workerContext.patchCard(
 				session,
 				typeCard!,


### PR DESCRIPTION
If a card is upserted by sync and the only change being made is to
/data/origin, skip the update as it conveys no useful information, since
there isn't any data change to be made.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>