### PR TITLE
Update oauth logs

### DIFF
--- a/lib/sync-context.ts
+++ b/lib/sync-context.ts
@@ -227,6 +227,11 @@ export const getActionContext = (
 			);
 		},
 		getElementBySlug: async (slug: string) => {
+			logger.info(context, 'Getting element by slug from sync context', {
+				slug,
+				session,
+			});
+
 			return workerContext.getCardBySlug(session, slug);
 		},
 		getElementById: async (id: string) => {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Related to: https://github.com/product-os/jellyfish-sync/pull/1130

Not looking to keep these logs in permanently, just want to get some more detailed information from production when attempting to sync real Outreach data. I believe I know what is happening and have been able to reproduce something very similar locally, but want to confirm my findings before attempting to merge https://github.com/product-os/jellyfish-sync/pull/1130.